### PR TITLE
web: chunk transfers 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+web/wasm_exec.js
+web/cryptowrap.wasm

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,7 @@
 <body>
 <form id="dialog">
 <div><label id="filepicker-wrap" class="button"><input type="file" id="filepicker">OPEN</label><p id="info">TYPE WORMHOLE CODE OR LEAVE EMPTY TO GENERATE A NEW ONE</p></div>
+<ul id="transfers"></ul>
 <input type="text" id="magiccode" placeholder="CODE">
 <input type="submit" id="dial" value="CONNECT" autocomplete="off" disabled>
 </form>

--- a/web/style.css
+++ b/web/style.css
@@ -53,6 +53,15 @@ body.highlight {
 	display: inline-block;
 }
 
+#transfers {
+	margin: 0;
+	display: none;
+	list-style-type: none;
+}
+.connected #transfers {
+	display: unset;
+}
+
 #magiccode {
 	margin: 16px;
 	font-size: 2em;


### PR DESCRIPTION
This restricts the size of messages which means much better cross-browser support. Tested on macOS Chrome, Firefox, and Safari and iOS Safari.

This also makes the web UI is much better at handling large (but not humongous) files.

Closes  #11 and #5.
